### PR TITLE
Updated plugins url

### DIFF
--- a/root/README.md
+++ b/root/README.md
@@ -1,6 +1,6 @@
 # Ractive.js {%= name %} {%= type %} plugin
 
-*Find more Ractive.js plugins at [ractivejs.org/plugins](http://ractivejs.org/plugins)*
+*Find more Ractive.js plugins at [docs.ractivejs.org/latest/plugins](http://docs.ractivejs.org/latest/plugins)*
 
 [See the demo here.](TODO)
 


### PR DESCRIPTION
ractivejs.org/plugins leads no where.. docs.ractivejs.org/latest/plugins on the other hand.. :)
